### PR TITLE
Fix clippy lints.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "amplify"
-version = "3.12.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45c604e86700ffea68a7d90c3ffb1508dad1120902f31dbb08afc942cf8acf3"
+checksum = "116019a174e912931d5b19ca7ab6a22596d12cdb1320358fad3368f0aba135a9"
 dependencies = [
  "amplify_apfloat",
  "amplify_derive",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "bp-core"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37606d0f9b2c13cc1ac5bf81dbe4dc57479edc86d891be62235ca415b21600b"
+checksum = "a21c38adb69d890aa90c175240e3f5b1784cf6626486e7fd5138e3e6f6168101"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "bp-dbc"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cad35fd1f038ab75f078b3d51a005162905fe0f915b3efd14eb89a5c26dae5"
+checksum = "2b579033858923b066ad644f2628f20472694723e3aad6da1f678c9e9ff029db"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "bp-seals"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c06a238a7121b96522c327148e26d176e87ef0f10e5d9ad09945df9bb3c44d6"
+checksum = "014b7cddf7739a960b504db916041e7605ee60aa56c885673948c55b634bdc96"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_derive_helpers"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1031494858bb61a17feb9e51f0bc2d0a397d7fefa1f0a9e92f6e260912d51d7"
+checksum = "d8a2293d9a54744b73b753fad2e3c16295345504dc230696ee8aa5dbfd276ab4"
 dependencies = [
  "amplify",
  "proc-macro2",
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "heck"
@@ -864,9 +864,9 @@ checksum = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-core"
-version = "0.8.0-rc.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba54d26545b77f15d484e9854145bfb41c6428fd209241933d4237704c4eb77"
+checksum = "71a0efaa4a4c85acf6159148d92af402f37821eb197c66018723f605b6cfc0be"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1294,18 +1294,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
 dependencies = [
  "indexmap",
  "ryu",
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "stens"
-version = "0.5.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310f88dd6b45bd329abafc54869d476e9a7ad813b04adc162d62d6c5e94af46a"
+checksum = "6e4804a8a3d876fc0933294ff3d30c5353107ac88dfbab9d4283305b496c02ae"
 dependencies = [
  "amplify",
  "serde",
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "strict_encoding"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0cffbeaff0c2b9981412ac471b7d99cb4adcff75a6967114ea36cd8faae930"
+checksum = "5a5fa61708f858144b37d2c10bafe95724dbc917f7ea491456d0069789f8f5f3"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -1725,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["cli"]
 [dependencies]
 amplify = "3.12.1"
 strict_encoding = "~0.8.0"
-stens = "0.5.0"
+stens = "0.7.1"
 lnpbp = "0.8.0"
 bp-seals = "0.8.0-rc.1"
 rgb-std = { version = "0.8.0-rc.2", features = ["wallet"] }

--- a/src/create.rs
+++ b/src/create.rs
@@ -26,6 +26,7 @@ use crate::schema;
 use crate::schema::{FieldType, OwnedRightType};
 
 /// Extension trait for consignments defining RGB20-specific API.
+#[allow(clippy::too_many_arguments)]
 pub trait Rgb20<'consignment>: Consignment<'consignment> {
     /// Performs primary asset issue, producing [`Contract`] consignment.
     fn create_rgb20(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -23,12 +23,12 @@ use rgb::ValidationScript;
 use stens::{PrimitiveType, StructField, TypeRef, TypeSystem};
 
 /// Schema identifier for full RGB20 fungible asset
-pub const SCHEMA_ID_BECH32: &'static str =
+pub const SCHEMA_ID_BECH32: &str =
     "rgbsh1kqth3x9xa5qde0vve0avfe40s28xzsjqds3dg0crv353uhmaawzs9n6k8y";
 
 /// Schema identifier for full RGB20 fungible asset subschema prohibiting burn &
 /// replace operations
-pub const SUBSCHEMA_ID_BECH32: &'static str =
+pub const SUBSCHEMA_ID_BECH32: &str =
     "rgbsh190z9zepf8rmla9kqc0qsptchunxjmv3xkg2hnjf2v7v093z3nc9q55d54x";
 
 /// Field types for RGB20 schemata
@@ -73,7 +73,9 @@ pub enum FieldType {
 
 impl From<FieldType> for rgb::schema::FieldType {
     #[inline]
-    fn from(ft: FieldType) -> Self { ft as rgb::schema::FieldType }
+    fn from(ft: FieldType) -> Self {
+        ft as rgb::schema::FieldType
+    }
 }
 
 /// Owned right types used by RGB20 schemata
@@ -101,7 +103,9 @@ pub enum OwnedRightType {
 
 impl From<OwnedRightType> for rgb::schema::OwnedRightType {
     #[inline]
-    fn from(t: OwnedRightType) -> Self { t as rgb::schema::OwnedRightType }
+    fn from(t: OwnedRightType) -> Self {
+        t as rgb::schema::OwnedRightType
+    }
 }
 
 /// State transition types defined by RGB20 schemata
@@ -136,13 +140,15 @@ pub enum TransitionType {
 
 impl From<TransitionType> for rgb::schema::TransitionType {
     #[inline]
-    fn from(t: TransitionType) -> Self { t as rgb::schema::TransitionType }
+    fn from(t: TransitionType) -> Self {
+        t as rgb::schema::TransitionType
+    }
 }
 
 fn type_system() -> TypeSystem {
     type_system! {
         "OutPoint" :: {
-            StructField::new("Txid"),
+            StructField::with("Txid"),
             StructField::primitive(PrimitiveType::U16),
         },
         "Txid" :: { StructField::array(PrimitiveType::U8, 32) }

--- a/src/transitions.rs
+++ b/src/transitions.rs
@@ -140,9 +140,9 @@ impl Asset {
         for coin in input_usto {
             parent
                 .entry(coin.outpoint.node_id)
-                .or_insert(empty!())
+                .or_insert_with(|| empty!())
                 .entry(OwnedRightType::Assets.into())
-                .or_insert(empty!())
+                .or_insert_with(|| empty!())
                 .push(coin.outpoint.no);
         }
 


### PR DESCRIPTION
I need to have stens on 0.7.1 so I can pull this crate into code I'm using that also uses bp-core and rgb-std.

I updated stens, but it invalidated the test assertions.
![Screenshot from 2022-07-13 17-49-59](https://user-images.githubusercontent.com/285690/178856107-1740c798-20d6-4f85-8a96-74633dcfcd30.png)

I'm not sure what the best decision is for that.