### PR TITLE
fix: missing rgb20 bin path in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["rlib", "staticlib"]
 
 [[bin]]
 name = "rgb20"
+path = "src/bin/rgb20.rs"
 required-features = ["cli"]
 
 [dependencies]


### PR DESCRIPTION
While building, I ran into the following error:
```shell
error: failed to parse manifest at `/usr/local/src/rgb20/Cargo.toml`

Caused by:
  cannot infer path for `rgb20` bin
  Cargo doesn't know which to use because multiple target files found at `src/main.rs` and `src/bin/rgb20.rs`.
```

As no path is specified for the `rgb20` bin in `Cargo.toml`, Cargo doesn't know which one to use between the default one for the first binary `src/main.rs` and the default one for next binaries `src/bin/<binary>.rs` (see https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries).

This PR had the explicit path `src/bin/rgb20.rs`. It fixes my build issue.
