### PR TITLE
Define RGB20 subschemata

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -12,7 +12,9 @@
 use std::collections::btree_set;
 
 use bitcoin::OutPoint;
-use rgb::{ConsignmentType, ContractState, InmemConsignment, NodeId, OwnedValue};
+use rgb::{ConsignmentType, ContractState, InmemConsignment, NodeId, OwnedValue, Schema};
+
+use crate::Rgb20Schemata;
 
 /// RGB20 asset information.
 ///
@@ -72,7 +74,7 @@ where T: ConsignmentType
 
 impl Asset {
     fn validate(&self) -> Result<(), Error> {
-        if self.0.schema_id != crate::schema().schema_id() {
+        if self.0.schema_id != Schema::rgb20_root().schema_id() {
             Err(Error::WrongSchemaId)?;
         }
         // TODO: Validate the state

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -14,7 +14,7 @@ use std::collections::btree_set;
 use bitcoin::OutPoint;
 use rgb::{ConsignmentType, ContractState, InmemConsignment, NodeId, OwnedValue, Schema};
 
-use crate::Rgb20Schemata;
+use crate::schema::Rgb20Schemata;
 
 /// RGB20 asset information.
 ///

--- a/src/create.rs
+++ b/src/create.rs
@@ -22,7 +22,7 @@ use rgb::{
 };
 use stens::AsciiString;
 
-use crate::{FieldType, OwnedRightType, Rgb20Schemata};
+use crate::schema::{FieldType, OwnedRightType, Rgb20Schemata};
 
 /// Extension trait for consignments defining RGB20-specific API.
 #[allow(clippy::too_many_arguments)]

--- a/src/create.rs
+++ b/src/create.rs
@@ -18,12 +18,12 @@ use rgb::fungible::allocation::{
     AllocationMap, IntoSealValueMap, OutpointValueMap, OutpointValueVec,
 };
 use rgb::{
-    data, secp256k1zkp, value, Assignment, Consignment, Contract, Genesis, TypedAssignments,
+    data, secp256k1zkp, value, Assignment, Consignment, Contract, Genesis, Schema, TypedAssignments,
 };
 use stens::AsciiString;
 
-use crate::schema;
 use crate::schema::{FieldType, OwnedRightType};
+use crate::Rgb20Schemata;
 
 /// Extension trait for consignments defining RGB20-specific API.
 #[allow(clippy::too_many_arguments)]
@@ -102,7 +102,7 @@ impl<'consignment> Rgb20<'consignment> for Contract {
             );
         }
 
-        let schema = schema::schema();
+        let schema = Schema::rgb20_root();
 
         let genesis = Genesis::with(
             schema.schema_id(),

--- a/src/create.rs
+++ b/src/create.rs
@@ -22,8 +22,7 @@ use rgb::{
 };
 use stens::AsciiString;
 
-use crate::schema::{FieldType, OwnedRightType};
-use crate::Rgb20Schemata;
+use crate::{FieldType, OwnedRightType, Rgb20Schemata};
 
 /// Extension trait for consignments defining RGB20-specific API.
 #[allow(clippy::too_many_arguments)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,10 @@ extern crate serde_crate as serde;
 #[cfg(feature = "serde")]
 extern crate serde_with;
 
-mod schema;
+pub mod schema;
 mod create;
 mod asset;
 mod transitions;
 
 pub use asset::{Asset, Error};
 pub use create::Rgb20;
-pub use schema::new::{FieldType, OwnedRightType, Rgb20Schemata, TransitionType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,4 +51,6 @@ mod transitions;
 
 pub use asset::{Asset, Error};
 pub use create::Rgb20;
-pub use schema::{schema, subschema, SCHEMA_ID_BECH32, SUBSCHEMA_ID_BECH32};
+pub use schema::{
+    schema, subschema_inflationary, BECH32_SCHEMA_ID_INFLATIONARY, BECH32_SCHEMA_ID_ROOT,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,4 +51,4 @@ mod transitions;
 
 pub use asset::{Asset, Error};
 pub use create::Rgb20;
-pub use schema::Rgb20Schemata;
+pub use schema::{FieldType, OwnedRightType, Rgb20Schemata};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,4 @@ mod transitions;
 
 pub use asset::{Asset, Error};
 pub use create::Rgb20;
-pub use schema::{
-    Rgb20Schemata, BECH32_SCHEMA_ID_INFLATIONARY, BECH32_SCHEMA_ID_ROOT, BECH32_SCHEMA_ID_SIMPLE,
-};
+pub use schema::Rgb20Schemata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,4 +51,4 @@ mod transitions;
 
 pub use asset::{Asset, Error};
 pub use create::Rgb20;
-pub use schema::{FieldType, OwnedRightType, Rgb20Schemata};
+pub use schema::new::{FieldType, OwnedRightType, Rgb20Schemata, TransitionType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ extern crate serde_crate as serde;
 #[cfg(feature = "serde")]
 extern crate serde_with;
 
-pub mod schema;
+mod schema;
 mod create;
 mod asset;
 mod transitions;
@@ -52,5 +52,5 @@ mod transitions;
 pub use asset::{Asset, Error};
 pub use create::Rgb20;
 pub use schema::{
-    schema, subschema_inflationary, BECH32_SCHEMA_ID_INFLATIONARY, BECH32_SCHEMA_ID_ROOT,
+    Rgb20Schemata, BECH32_SCHEMA_ID_INFLATIONARY, BECH32_SCHEMA_ID_ROOT, BECH32_SCHEMA_ID_SIMPLE,
 };

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -369,7 +369,7 @@ impl Rgb20Schemata for Schema {
                 OwnedRightType::Assets => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
                 OwnedRightType::OpenEpoch => StateSchema::Declarative,
                 OwnedRightType::BurnReplace => StateSchema::Declarative,
-                OwnedRightType::Renomination => StateSchema::DataContainer
+                OwnedRightType::Renomination => StateSchema::Declarative
             },
             public_right_types: none!(),
             script: ValidationScript::Embedded,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,7 +33,7 @@ pub const BECH32_SCHEMA_ID_INFLATIONARY: &str =
 
 /// Schema identifier for RGB20 fungible asset allowing just asset transfers.
 pub const BECH32_SCHEMA_ID_SIMPLE: &str =
-    "rgbsh1wu3c89xkwtgjf5eh2sah6phrw9jfrq6cf3c8hsltq74x737tk7msjxa0p5";
+    "rgbsh1pxeg6w0n29cmaw6cl2chp5lh4tygxeqqyufr2rzkhppvtl8xqaaqqhjh3s";
 
 /// Field types for RGB20 schemata
 ///
@@ -547,6 +547,16 @@ mod test {
     }
 
     #[test]
+    fn subschema_simple_id() {
+        let id = Schema::rgb20_simple().schema_id();
+        assert_eq!(id.to_string(), BECH32_SCHEMA_ID_SIMPLE);
+        assert_eq!(
+            id.to_string(),
+            "rgbsh1pxeg6w0n29cmaw6cl2chp5lh4tygxeqqyufr2rzkhppvtl8xqaaqqhjh3s"
+        );
+    }
+
+    #[test]
     fn schema_strict_encode() {
         let data = Schema::rgb20_root()
             .strict_serialize()
@@ -575,6 +585,9 @@ mod test {
     #[test]
     fn subschema_verify() {
         let status = Schema::rgb20_inflationary().schema_verify(&Schema::rgb20_root());
+        assert_eq!(status.validity(), Validity::Valid);
+
+        let status = Schema::rgb20_simple().schema_verify(&Schema::rgb20_root());
         assert_eq!(status.validity(), Validity::Valid);
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -216,15 +216,15 @@ pub trait Rgb20Schemata {
     /// Schema identifier for RGB20 fungible asset supporting all possible asset
     /// operations.
     const RGB20_ROOT_BECH32: &'static str =
-        "rgbsh18kp34t5nn5zu4hz6g7lqjdjskw8aaf84ecdntrtrdvzs7gn3rnzskscfq8";
+        "rgbsh1hacf8gg863veu292hdnttynqzk5xdvyk5q2fxep3e85j4ttzd05s2j4ern";
 
     /// Schema identifier for RGB20 fungible asset allowing only inflation operation.
     const RGB20_INFLATIONARY_BECH32: &'static str =
-        "rgbsh1wu3c89xkwtgjf5eh2sah6phrw9jfrq6cf3c8hsltq74x737tk7msjxa0p5";
+        "rgbsh1qmts2pmfxt9e6tpuevk2v0dza30d9v4n0cq6vtm0jtppnyz5xrss4gj9wd";
 
     /// Schema identifier for RGB20 fungible asset allowing just asset transfers.
     const RGB20_SIMPLE_BECH32: &'static str =
-        "rgbsh1pxeg6w0n29cmaw6cl2chp5lh4tygxeqqyufr2rzkhppvtl8xqaaqqhjh3s";
+        "rgbsh13c3e8ywrmsu9j0k3er0lgzp9memn5c55rw5svf0l9n3sfntv76zqehteur";
 
     /// Builds & returns complete RGB20 schema (root schema object)
     fn rgb20_root() -> Schema;
@@ -539,7 +539,7 @@ mod test {
         assert_eq!(id.to_string(), Schema::RGB20_ROOT_BECH32);
         assert_eq!(
             id.to_string(),
-            "rgbsh18kp34t5nn5zu4hz6g7lqjdjskw8aaf84ecdntrtrdvzs7gn3rnzskscfq8"
+            "rgbsh1hacf8gg863veu292hdnttynqzk5xdvyk5q2fxep3e85j4ttzd05s2j4ern"
         );
     }
 
@@ -549,7 +549,7 @@ mod test {
         assert_eq!(id.to_string(), Schema::RGB20_INFLATIONARY_BECH32);
         assert_eq!(
             id.to_string(),
-            "rgbsh1wu3c89xkwtgjf5eh2sah6phrw9jfrq6cf3c8hsltq74x737tk7msjxa0p5"
+            "rgbsh1qmts2pmfxt9e6tpuevk2v0dza30d9v4n0cq6vtm0jtppnyz5xrss4gj9wd"
         );
     }
 
@@ -559,7 +559,7 @@ mod test {
         assert_eq!(id.to_string(), Schema::RGB20_SIMPLE_BECH32);
         assert_eq!(
             id.to_string(),
-            "rgbsh1pxeg6w0n29cmaw6cl2chp5lh4tygxeqqyufr2rzkhppvtl8xqaaqqhjh3s"
+            "rgbsh13c3e8ywrmsu9j0k3er0lgzp9memn5c55rw5svf0l9n3sfntv76zqehteur"
         );
     }
 
@@ -582,10 +582,11 @@ mod test {
         );
         assert_eq!(
             bech32data,
-            "z1qxz4zwcwcgcqcl2d2tgnrzqtwq33swqzfvt43zkyepg49ky655klwg7cfefgg4pf38ewe78em8u6qwq5rgwx\
-            ah03mf0r4pg2q6nhk7exy2a32c8hk3hns7lm4yvrf7ux6m8pr6y3vy3vtt75f356s2dyr4q576cq8n9k42va5ut\
-            rfqnw7ysnkgyytecfqzy034s2cxqzt0nwnzzkyun24a2ljuwqt8xd0k3q6sd0wm4zmexvnjn3pge7w98kkvq2xd\
-            yc2kv5aa2d2tekv6lke8f6jc6z4hf290ccq08plf4h3u2t8nllq9cyvya79"
+            "z1qxz4qjcwsgcpqld5lp94e4rcqx87xnskrmqe3vy3qscar828q8wuzp3cyp6kvjhaysfy4736xwhl8hjs3shg\
+            6fdk7yu5h5jmjsnvj5gp4w8rvvx8a6fy2jtueg2q9pxctl3sxd0cxqqvephjqk46ew5qgxdr296zmt4eeatts6r\
+            d50n694jmltsn4gszw2rgjaqv2xjnw8eelyjvfvwq4eh0rzfqr4sks2j4g7xdqjw6adtuxf868xasvawtw4llwm\
+            6pcntxhjdnhtw40l7s5quemlx7h2j4eu7cc33dfs3s4tt5xthhfldayax7d0yxd74lulmuplhvqe8sr54gn3mcq\
+            t6sylhqf2u"
         );
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -146,27 +146,6 @@ fn type_system() -> TypeSystem {
     }
 }
 
-fn issue() -> TransitionSchema {
-    use Occurrences::*;
-
-    TransitionSchema {
-        metadata: type_map! {
-            // We need this field in order to be able to verify pedersen
-            // commitments
-            FieldType::IssuedSupply => Once
-        },
-        closes: type_map! {
-            OwnedRightType::Inflation => OnceOrMore
-        },
-        owned_rights: type_map! {
-            OwnedRightType::Inflation => NoneOrMore,
-            OwnedRightType::OpenEpoch => NoneOrOnce,
-            OwnedRightType::Assets => NoneOrMore
-        },
-        public_rights: none!(),
-    }
-}
-
 fn burn() -> TransitionSchema {
     use Occurrences::*;
 
@@ -266,7 +245,22 @@ impl Rgb20Schemata for Schema {
             type_system: type_system(),
             extensions: none!(),
             transitions: type_map! {
-                TransitionType::Issue => issue(),
+                TransitionType::Issue => TransitionSchema {
+                    metadata: type_map! {
+                        // We need this field in order to be able to verify pedersen
+                        // commitments
+                        FieldType::IssuedSupply => Once
+                    },
+                    closes: type_map! {
+                        OwnedRightType::Inflation => OnceOrMore
+                    },
+                    owned_rights: type_map! {
+                        OwnedRightType::Inflation => NoneOrMore,
+                        OwnedRightType::OpenEpoch => NoneOrOnce,
+                        OwnedRightType::Assets => NoneOrMore
+                    },
+                    public_rights: none!(),
+                },
                 TransitionType::Transfer => TransitionSchema {
                     metadata: none!(),
                     closes: type_map! {
@@ -404,7 +398,21 @@ impl Rgb20Schemata for Schema {
             },
             extensions: none!(),
             transitions: type_map! {
-                TransitionType::Issue => issue(),
+                TransitionType::Issue => TransitionSchema {
+                    metadata: type_map! {
+                        // We need this field in order to be able to verify pedersen
+                        // commitments
+                        FieldType::IssuedSupply => Once
+                    },
+                    closes: type_map! {
+                        OwnedRightType::Inflation => OnceOrMore
+                    },
+                    owned_rights: type_map! {
+                        OwnedRightType::Inflation => NoneOrMore,
+                        OwnedRightType::Assets => NoneOrMore
+                    },
+                    public_rights: none!(),
+                },
                 TransitionType::Transfer => TransitionSchema {
                     metadata: none!(),
                     closes: type_map! {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -60,9 +60,6 @@ pub enum FieldType {
 
     /// Proofs of the burned supply
     HistoryProof = FIELD_TYPE_HISTORY_PROOF,
-
-    /// Media format for the information proving burned supply
-    HistoryProofFormat = FIELD_TYPE_HISTORY_PROOF_FORMAT,
 }
 
 impl From<FieldType> for rgb::schema::FieldType {
@@ -139,7 +136,13 @@ fn type_system() -> TypeSystem {
             StructField::with("Txid"),
             StructField::primitive(PrimitiveType::U16),
         },
-        "Txid" :: { StructField::array(PrimitiveType::U8, 32) }
+        "Txid" :: { StructField::array(PrimitiveType::U8, 32) },
+        "HistoryProof" :: {
+            // Format of the proof defined as an ASCII string
+            StructField::ascii_string(),
+            // Data for the proof
+            StructField::bytes()
+        }
     }
 }
 
@@ -175,7 +178,6 @@ fn burn() -> TransitionSchema {
             // mistake this will be impossible, so we allow to have
             // multiple burned UTXOs as a part of a single operation
             FieldType::BurnUtxo => OnceOrMore,
-            FieldType::HistoryProofFormat => Once,
             FieldType::HistoryProof => NoneOrMore
         },
         closes: type_map! {
@@ -298,7 +300,6 @@ impl Rgb20Schemata for Schema {
                         // We need this field in order to be able to verify pedersen
                         // commitments
                         FieldType::IssuedSupply => Once,
-                        FieldType::HistoryProofFormat => Once,
                         FieldType::HistoryProof => NoneOrMore
                     },
                     closes: type_map! {
@@ -357,7 +358,7 @@ impl Rgb20Schemata for Schema {
                 // even existed; so we prohibit all the dates before RGB release
                 // This timestamp is equal to 10/10/2020 @ 2:37pm (UTC)
                 FieldType::Timestamp => TypeRef::i64(),
-                FieldType::HistoryProof => TypeRef::bytes(),
+                FieldType::HistoryProof => TypeRef::new("HistoryProof"),
                 FieldType::BurnUtxo => TypeRef::new("OutPoint")
             },
             owned_right_types: type_map! {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -42,6 +42,9 @@ pub enum FieldType {
     /// Decimal precision
     Precision = FIELD_TYPE_PRECISION,
 
+    /// Ricardian contract for the asset
+    Contract = FIELD_TYPE_CONTRACT_TEXT,
+
     /// Supply issued with the genesis, secondary issuance or burn & replace
     /// state transition
     IssuedSupply = FIELD_TYPE_ISSUED_SUPPLY,
@@ -192,6 +195,7 @@ fn renomination() -> TransitionSchema {
         metadata: type_map! {
             FieldType::Ticker => NoneOrOnce,
             FieldType::Name => NoneOrOnce,
+            FieldType::Contract => NoneOrOnce,
             FieldType::Precision => NoneOrOnce
         },
         closes: type_map! {
@@ -242,6 +246,7 @@ impl Rgb20Schemata for Schema {
                 metadata: type_map! {
                     FieldType::Ticker => Once,
                     FieldType::Name => Once,
+                    FieldType::Contract => NoneOrOnce,
                     FieldType::Precision => Once,
                     FieldType::Timestamp => Once,
                     // We need this field in order to be able to verify pedersen
@@ -339,7 +344,8 @@ impl Rgb20Schemata for Schema {
                 // Ricardian contract, up to 64kb. If the contract doesn't fit, a
                 // double SHA256 hash and URL should be used instead, pointing to
                 // the full contract text, where hash must be represented by a
-                // hexadecimal string, optionally followed by `\n` and text URL
+                // hexadecimal string, optionally followed by `\n` and text URL.
+                FieldType::Contract => TypeRef::ascii_string(),
                 FieldType::Precision => TypeRef::u8(),
                 // We need this b/c allocated amounts are hidden behind Pedersen
                 // commitments

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -22,19 +22,6 @@ use rgb::vm::embedded::constants::*;
 use rgb::ValidationScript;
 use stens::{PrimitiveType, StructField, TypeRef, TypeSystem};
 
-/// Schema identifier for RGB20 fungible asset supporting all possible asset
-/// operations.
-pub const BECH32_SCHEMA_ID_ROOT: &str =
-    "rgbsh18kp34t5nn5zu4hz6g7lqjdjskw8aaf84ecdntrtrdvzs7gn3rnzskscfq8";
-
-/// Schema identifier for RGB20 fungible asset allowing only inflation operation.
-pub const BECH32_SCHEMA_ID_INFLATIONARY: &str =
-    "rgbsh1wu3c89xkwtgjf5eh2sah6phrw9jfrq6cf3c8hsltq74x737tk7msjxa0p5";
-
-/// Schema identifier for RGB20 fungible asset allowing just asset transfers.
-pub const BECH32_SCHEMA_ID_SIMPLE: &str =
-    "rgbsh1pxeg6w0n29cmaw6cl2chp5lh4tygxeqqyufr2rzkhppvtl8xqaaqqhjh3s";
-
 /// Field types for RGB20 schemata
 ///
 /// Subset of known RGB schema pre-defined types applicable to fungible assets.
@@ -220,6 +207,19 @@ fn renomination() -> TransitionSchema {
 /// Trait extension adding RGB20 schema constructors to the RGB Core Lib
 /// [`Schema`] object.
 pub trait Rgb20Schemata {
+    /// Schema identifier for RGB20 fungible asset supporting all possible asset
+    /// operations.
+    const RGB20_ROOT_BECH32: &'static str =
+        "rgbsh18kp34t5nn5zu4hz6g7lqjdjskw8aaf84ecdntrtrdvzs7gn3rnzskscfq8";
+
+    /// Schema identifier for RGB20 fungible asset allowing only inflation operation.
+    const RGB20_INFLATIONARY_BECH32: &'static str =
+        "rgbsh1wu3c89xkwtgjf5eh2sah6phrw9jfrq6cf3c8hsltq74x737tk7msjxa0p5";
+
+    /// Schema identifier for RGB20 fungible asset allowing just asset transfers.
+    const RGB20_SIMPLE_BECH32: &'static str =
+        "rgbsh1pxeg6w0n29cmaw6cl2chp5lh4tygxeqqyufr2rzkhppvtl8xqaaqqhjh3s";
+
     /// Builds & returns complete RGB20 schema (root schema object)
     fn rgb20_root() -> Schema;
 
@@ -376,7 +376,7 @@ impl Rgb20Schemata for Schema {
 
         Schema {
             rgb_features: none!(),
-            root_id: SchemaId::from_str(BECH32_SCHEMA_ID_ROOT)
+            root_id: SchemaId::from_str(Schema::RGB20_ROOT_BECH32)
                 .expect("Broken root schema ID for RGB20 sub-schema"),
             type_system: none!(),
             genesis: GenesisSchema {
@@ -460,7 +460,7 @@ impl Rgb20Schemata for Schema {
 
         Schema {
             rgb_features: none!(),
-            root_id: SchemaId::from_str(BECH32_SCHEMA_ID_ROOT)
+            root_id: SchemaId::from_str(Schema::RGB20_ROOT_BECH32)
                 .expect("Broken root schema ID for RGB20 sub-schema"),
             type_system: none!(),
             genesis: GenesisSchema {
@@ -529,7 +529,7 @@ mod test {
     #[test]
     fn schema_id() {
         let id = Schema::rgb20_root().schema_id();
-        assert_eq!(id.to_string(), BECH32_SCHEMA_ID_ROOT);
+        assert_eq!(id.to_string(), Schema::RGB20_ROOT_BECH32);
         assert_eq!(
             id.to_string(),
             "rgbsh18kp34t5nn5zu4hz6g7lqjdjskw8aaf84ecdntrtrdvzs7gn3rnzskscfq8"
@@ -539,7 +539,7 @@ mod test {
     #[test]
     fn subschema_inflationary_id() {
         let id = Schema::rgb20_inflationary().schema_id();
-        assert_eq!(id.to_string(), BECH32_SCHEMA_ID_INFLATIONARY);
+        assert_eq!(id.to_string(), Schema::RGB20_INFLATIONARY_BECH32);
         assert_eq!(
             id.to_string(),
             "rgbsh1wu3c89xkwtgjf5eh2sah6phrw9jfrq6cf3c8hsltq74x737tk7msjxa0p5"
@@ -549,7 +549,7 @@ mod test {
     #[test]
     fn subschema_simple_id() {
         let id = Schema::rgb20_simple().schema_id();
-        assert_eq!(id.to_string(), BECH32_SCHEMA_ID_SIMPLE);
+        assert_eq!(id.to_string(), Schema::RGB20_SIMPLE_BECH32);
         assert_eq!(
             id.to_string(),
             "rgbsh1pxeg6w0n29cmaw6cl2chp5lh4tygxeqqyufr2rzkhppvtl8xqaaqqhjh3s"

--- a/src/schema/legacy.rs
+++ b/src/schema/legacy.rs
@@ -1,0 +1,512 @@
+// RGB20 Library: high-level API to RGB fungible assets.
+// Written in 2019-2022 by
+//     Dr. Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// To the extent possible under law, the author(s) have dedicated all copyright
+// and related and neighboring rights to this software to the public domain
+// worldwide. This software is distributed without any warranty.
+//
+// You should have received a copy of the MIT License along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+//! Legacy RGB20 schemata defining fungible asset smart contract prototypes.
+
+use std::str::FromStr;
+
+use rgb::schema::{
+    DiscreteFiniteFieldFormat, GenesisSchema, Occurrences, Schema, SchemaId, StateSchema,
+    TransitionSchema,
+};
+use rgb::script::OverrideRules;
+use rgb::vm::embedded::constants::*;
+use rgb::ValidationScript;
+use stens::{PrimitiveType, StructField, TypeRef, TypeSystem};
+
+/// Schema identifier for full RGB20 fungible asset
+pub const SCHEMA_ID_BECH32: &str =
+    "rgbsh18kp34t5nn5zu4hz6g7lqjdjskw8aaf84ecdntrtrdvzs7gn3rnzskscfq8";
+
+/// Schema identifier for full RGB20 fungible asset subschema prohibiting burn &
+/// replace operations
+pub const SUBSCHEMA_ID_BECH32: &str =
+    "rgbsh1636y76cxrnsfqg7zjnl08f0kqt9j09tre2wfxzrrs86f76ssp7cqnn0yyf";
+
+/// Field types for RGB20 schemata
+///
+/// Subset of known RGB schema pre-defined types applicable to fungible assets.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
+#[display(Debug)]
+#[repr(u16)]
+pub enum FieldType {
+    /// Asset ticker
+    ///
+    /// Used within context of genesis or renomination state transition
+    Ticker = FIELD_TYPE_TICKER,
+
+    /// Asset name
+    ///
+    /// Used within context of genesis or renomination state transition
+    Name = FIELD_TYPE_NAME,
+
+    /// Decimal precision
+    Precision = FIELD_TYPE_PRECISION,
+
+    /// Supply issued with the genesis, secondary issuance or burn & replace
+    /// state transition
+    IssuedSupply = FIELD_TYPE_ISSUED_SUPPLY,
+
+    /// Supply burned with the burn or burn & replace state transition
+    BurnedSupply = FIELD_TYPE_BURN_SUPPLY,
+
+    /// Timestamp for genesis
+    Timestamp = FIELD_TYPE_TIMESTAMP,
+
+    /// UTXO containing the burned asset
+    BurnUtxo = FIELD_TYPE_BURN_UTXO,
+
+    /// Proofs of the burned supply
+    HistoryProof = FIELD_TYPE_HISTORY_PROOF,
+
+    /// Media format for the information proving burned supply
+    HistoryProofFormat = FIELD_TYPE_HISTORY_PROOF_FORMAT,
+}
+
+impl From<FieldType> for rgb::schema::FieldType {
+    #[inline]
+    fn from(ft: FieldType) -> Self { ft as rgb::schema::FieldType }
+}
+
+/// Owned right types used by RGB20 schemata
+///
+/// Subset of known RGB schema pre-defined types applicable to fungible assets.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
+#[display(Debug)]
+#[repr(u16)]
+pub enum OwnedRightType {
+    /// Inflation control right (secondary issuance right)
+    Inflation = STATE_TYPE_INFLATION_RIGHT,
+
+    /// Asset ownership right
+    Assets = STATE_TYPE_OWNERSHIP_RIGHT,
+
+    /// Right to open a new burn & replace epoch
+    OpenEpoch = STATE_TYPE_ISSUE_EPOCH_RIGHT,
+
+    /// Right to perform burn or burn & replace operation
+    BurnReplace = STATE_TYPE_ISSUE_REPLACEMENT_RIGHT,
+
+    /// Right to perform asset renomination
+    Renomination = STATE_TYPE_RENOMINATION_RIGHT,
+}
+
+impl From<OwnedRightType> for rgb::schema::OwnedRightType {
+    #[inline]
+    fn from(t: OwnedRightType) -> Self { t as rgb::schema::OwnedRightType }
+}
+
+/// State transition types defined by RGB20 schemata
+///
+/// Subset of known RGB schema pre-defined types applicable to fungible assets.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
+#[display(Debug)]
+#[repr(u16)]
+pub enum TransitionType {
+    /// Secondary issuance
+    Issue = TRANSITION_TYPE_ISSUE_FUNGIBLE,
+
+    /// Asset transfer
+    Transfer = TRANSITION_TYPE_VALUE_TRANSFER,
+
+    /// Opening of the new burn & replace asset epoch
+    Epoch = TRANSITION_TYPE_ISSUE_EPOCH,
+
+    /// Asset burn operation
+    Burn = TRANSITION_TYPE_ISSUE_BURN,
+
+    /// Burning and replacement (re-issuance) of the asset
+    BurnAndReplace = TRANSITION_TYPE_ISSUE_REPLACE,
+
+    /// Renomination (change in the asset name, ticker, contract text of
+    /// decimal precision).
+    Renomination = TRANSITION_TYPE_RENOMINATION,
+
+    /// Operation splitting rights assigned to the same UTXO
+    RightsSplit = TRANSITION_TYPE_RIGHTS_SPLIT,
+}
+
+impl From<TransitionType> for rgb::schema::TransitionType {
+    #[inline]
+    fn from(t: TransitionType) -> Self { t as rgb::schema::TransitionType }
+}
+
+fn type_system() -> TypeSystem {
+    type_system! {
+        "OutPoint" :: {
+            StructField::with("Txid"),
+            StructField::primitive(PrimitiveType::U16),
+        },
+        "Txid" :: { StructField::array(PrimitiveType::U8, 32) }
+    }
+}
+
+fn genesis() -> GenesisSchema {
+    use Occurrences::*;
+
+    GenesisSchema {
+        metadata: type_map! {
+            FieldType::Ticker => Once,
+            FieldType::Name => Once,
+            FieldType::Precision => Once,
+            FieldType::Timestamp => Once,
+            // We need this field in order to be able to verify pedersen
+            // commitments
+            FieldType::IssuedSupply => Once
+        },
+        owned_rights: type_map! {
+            OwnedRightType::Inflation => NoneOrMore,
+            OwnedRightType::OpenEpoch => NoneOrOnce,
+            OwnedRightType::Assets => NoneOrMore,
+            OwnedRightType::Renomination => NoneOrOnce
+        },
+        public_rights: none!(),
+    }
+}
+
+fn issue() -> TransitionSchema {
+    use Occurrences::*;
+
+    TransitionSchema {
+        metadata: type_map! {
+            // We need this field in order to be able to verify pedersen
+            // commitments
+            FieldType::IssuedSupply => Once
+        },
+        closes: type_map! {
+            OwnedRightType::Inflation => OnceOrMore
+        },
+        owned_rights: type_map! {
+            OwnedRightType::Inflation => NoneOrMore,
+            OwnedRightType::OpenEpoch => NoneOrOnce,
+            OwnedRightType::Assets => NoneOrMore
+        },
+        public_rights: none!(),
+    }
+}
+
+fn burn() -> TransitionSchema {
+    use Occurrences::*;
+
+    TransitionSchema {
+        metadata: type_map! {
+            FieldType::BurnedSupply => Once,
+            // Normally issuer should aggregate burned assets into a
+            // single UTXO; however if burn happens as a result of
+            // mistake this will be impossible, so we allow to have
+            // multiple burned UTXOs as a part of a single operation
+            FieldType::BurnUtxo => OnceOrMore,
+            FieldType::HistoryProofFormat => Once,
+            FieldType::HistoryProof => NoneOrMore
+        },
+        closes: type_map! {
+            OwnedRightType::BurnReplace => Once
+        },
+        owned_rights: type_map! {
+            OwnedRightType::BurnReplace => NoneOrOnce
+        },
+        public_rights: none!(),
+    }
+}
+
+fn renomination() -> TransitionSchema {
+    use Occurrences::*;
+
+    TransitionSchema {
+        metadata: type_map! {
+            FieldType::Ticker => NoneOrOnce,
+            FieldType::Name => NoneOrOnce,
+            FieldType::Precision => NoneOrOnce
+        },
+        closes: type_map! {
+            OwnedRightType::Renomination => Once
+        },
+        owned_rights: type_map! {
+            OwnedRightType::Renomination => NoneOrOnce
+        },
+        public_rights: none!(),
+    }
+}
+
+/// Builds & returns complete RGB20 schema (root schema object)
+pub fn schema() -> Schema {
+    use Occurrences::*;
+
+    Schema {
+        rgb_features: none!(),
+        root_id: none!(),
+        genesis: genesis(),
+        type_system: type_system(),
+        extensions: none!(),
+        transitions: type_map! {
+            TransitionType::Issue => issue(),
+            TransitionType::Transfer => TransitionSchema {
+                metadata: none!(),
+                closes: type_map! {
+                    OwnedRightType::Assets => OnceOrMore
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::Assets => NoneOrMore
+                },
+                public_rights: none!()
+            },
+            TransitionType::Epoch => TransitionSchema {
+                metadata: none!(),
+                closes: type_map! {
+                    OwnedRightType::OpenEpoch => Once
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::OpenEpoch => NoneOrOnce,
+                    OwnedRightType::BurnReplace => NoneOrOnce
+                },
+                public_rights: none!()
+            },
+            TransitionType::Burn => burn(),
+            TransitionType::BurnAndReplace => TransitionSchema {
+                metadata: type_map! {
+                    FieldType::BurnedSupply => Once,
+                    // Normally issuer should aggregate burned assets into a
+                    // single UTXO; however if burn happens as a result of
+                    // mistake this will be impossible, so we allow to have
+                    // multiple burned UTXOs as a part of a single operation
+                    FieldType::BurnUtxo => OnceOrMore,
+                    // We need this field in order to be able to verify pedersen
+                    // commitments
+                    FieldType::IssuedSupply => Once,
+                    FieldType::HistoryProofFormat => Once,
+                    FieldType::HistoryProof => NoneOrMore
+                },
+                closes: type_map! {
+                    OwnedRightType::BurnReplace => Once
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::BurnReplace => NoneOrOnce,
+                    OwnedRightType::Assets => OnceOrMore
+                },
+                public_rights: none!()
+            },
+            TransitionType::Renomination => renomination(),
+            // Allows split of rights if they were occasionally allocated to the
+            // same UTXO, for instance both assets and issuance right. Without
+            // this type of transition either assets or inflation rights will be
+            // lost.
+            TransitionType::RightsSplit => TransitionSchema {
+                metadata: type_map! {},
+                closes: type_map! {
+                    OwnedRightType::Inflation => NoneOrMore,
+                    OwnedRightType::Assets => NoneOrMore,
+                    OwnedRightType::OpenEpoch => NoneOrOnce,
+                    OwnedRightType::BurnReplace => NoneOrMore,
+                    OwnedRightType::Renomination => NoneOrOnce
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::Inflation => NoneOrMore,
+                    OwnedRightType::Assets => NoneOrMore,
+                    OwnedRightType::OpenEpoch => NoneOrOnce,
+                    OwnedRightType::BurnReplace => NoneOrMore,
+                    OwnedRightType::Renomination => NoneOrOnce
+                },
+                public_rights: none!()
+            }
+        },
+        field_types: type_map! {
+            // Rational: if we will use just 26 letters of English alphabet (and
+            // we are not limited by them), we will have 26^8 possible tickers,
+            // i.e. > 208 trillions, which is sufficient amount
+            FieldType::Ticker => TypeRef::ascii_string(),
+            FieldType::Name => TypeRef::ascii_string(),
+            // Contract text may contain URL, text or text representation of
+            // Ricardian contract, up to 64kb. If the contract doesn't fit, a
+            // double SHA256 hash and URL should be used instead, pointing to
+            // the full contract text, where hash must be represented by a
+            // hexadecimal string, optionally followed by `\n` and text URL
+            FieldType::Precision => TypeRef::u8(),
+            // We need this b/c allocated amounts are hidden behind Pedersen
+            // commitments
+            FieldType::IssuedSupply => TypeRef::u64(),
+            // Supply in either burn or burn-and-replace procedure
+            FieldType::BurnedSupply => TypeRef::u64(),
+            // While UNIX timestamps allow negative numbers; in context of RGB
+            // Schema, assets can't be issued in the past before RGB or Bitcoin
+            // even existed; so we prohibit all the dates before RGB release
+            // This timestamp is equal to 10/10/2020 @ 2:37pm (UTC)
+            FieldType::Timestamp => TypeRef::i64(),
+            FieldType::HistoryProof => TypeRef::bytes(),
+            FieldType::BurnUtxo => TypeRef::new("OutPoint")
+        },
+        owned_right_types: type_map! {
+            // How much issuer can issue tokens on this path. If there is no
+            // limit, than `core::u64::MAX` / sum(inflation_assignments)
+            // must be used, as this will be a de-facto limit to the
+            // issuance
+            OwnedRightType::Inflation => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
+            OwnedRightType::Assets => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
+            OwnedRightType::OpenEpoch => StateSchema::Declarative,
+            OwnedRightType::BurnReplace => StateSchema::Declarative,
+            OwnedRightType::Renomination => StateSchema::DataContainer
+        },
+        public_right_types: none!(),
+        script: ValidationScript::Embedded,
+        override_rules: OverrideRules::AllowAnyVm,
+    }
+}
+
+/// Provides the only defined RGB20 subschema, which prohibits replace procedure
+/// and allows only burn operations
+pub fn subschema() -> Schema {
+    use Occurrences::*;
+
+    Schema {
+        rgb_features: none!(),
+        root_id: SchemaId::from_str(SCHEMA_ID_BECH32)
+            .expect("Broken root schema ID for RGB20 sub-schema"),
+        type_system: type_system(),
+        genesis: genesis(),
+        extensions: none!(),
+        transitions: type_map! {
+            TransitionType::Issue => issue(),
+            TransitionType::Transfer => TransitionSchema {
+                metadata: none!(),
+                closes: type_map! {
+                    OwnedRightType::Assets => OnceOrMore
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::Assets => NoneOrMore
+                },
+                public_rights: none!()
+            },
+            TransitionType::Epoch => TransitionSchema {
+                metadata: none!(),
+                closes: type_map! {
+                    OwnedRightType::OpenEpoch => Once
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::BurnReplace => NoneOrOnce
+                },
+                public_rights: none!()
+            },
+            TransitionType::Burn => burn(),
+            TransitionType::Renomination => renomination(),
+            // Allows split of rights if they were occasionally allocated to the
+            // same UTXO, for instance both assets and issuance right. Without
+            // this type of transition either assets or inflation rights will be
+            // lost.
+            TransitionType::RightsSplit => TransitionSchema {
+                metadata: type_map! {},
+                closes: type_map! {
+                    OwnedRightType::Inflation => NoneOrMore,
+                    OwnedRightType::Assets => NoneOrMore,
+                    OwnedRightType::BurnReplace => NoneOrMore,
+                    OwnedRightType::Renomination => NoneOrOnce
+                },
+                owned_rights: type_map! {
+                    OwnedRightType::Inflation => NoneOrMore,
+                    OwnedRightType::Assets => NoneOrMore,
+                    OwnedRightType::BurnReplace => NoneOrMore,
+                    OwnedRightType::Renomination => NoneOrOnce
+                },
+                public_rights: none!()
+            }
+        },
+        field_types: type_map! {
+            // Rational: if we will use just 26 letters of English alphabet (and
+            // we are not limited by them), we will have 26^8 possible tickers,
+            // i.e. > 208 trillions, which is sufficient amount
+            FieldType::Ticker => TypeRef::ascii_string(),
+            FieldType::Name => TypeRef::ascii_string(),
+            FieldType::Precision => TypeRef::u8(),
+            // We need this b/c allocated amounts are hidden behind Pedersen
+            // commitments
+            FieldType::IssuedSupply => TypeRef::u64(),
+            // Supply in either burn or burn-and-replace procedure
+            FieldType::BurnedSupply => TypeRef::u64(),
+            // While UNIX timestamps allow negative numbers; in context of RGB
+            // Schema, assets can't be issued in the past before RGB or Bitcoin
+            // even existed; so we prohibit all the dates before RGB release
+            // This timestamp is equal to 10/10/2020 @ 2:37pm (UTC)
+            FieldType::Timestamp => TypeRef::i64(),
+            FieldType::BurnUtxo => TypeRef::new("OutPoint")
+        },
+        owned_right_types: type_map! {
+            // How much issuer can issue tokens on this path. If there is no
+            // limit, than `core::u64::MAX` / sum(inflation_assignments)
+            // must be used, as this will be a de-facto limit to the
+            // issuance
+            OwnedRightType::Inflation => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
+            OwnedRightType::Assets => StateSchema::DiscreteFiniteField(DiscreteFiniteFieldFormat::Unsigned64bit),
+            OwnedRightType::OpenEpoch => StateSchema::Declarative,
+            OwnedRightType::BurnReplace => StateSchema::Declarative,
+            OwnedRightType::Renomination => StateSchema::DataContainer
+        },
+        public_right_types: none!(),
+        script: ValidationScript::Embedded,
+        override_rules: OverrideRules::AllowAnyVm,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use lnpbp::bech32::Bech32ZipString;
+    use rgb::schema::SchemaVerify;
+    use rgb::Validity;
+    use strict_encoding::{StrictDecode, StrictEncode};
+
+    use super::*;
+
+    #[test]
+    fn schema_id() {
+        let id = schema().schema_id();
+        assert_eq!(id.to_string(), SCHEMA_ID_BECH32);
+        assert_eq!(
+            id.to_string(),
+            "rgbsh18kp34t5nn5zu4hz6g7lqjdjskw8aaf84ecdntrtrdvzs7gn3rnzskscfq8"
+        );
+    }
+
+    #[test]
+    fn subschema_id() {
+        let id = subschema().schema_id();
+        assert_eq!(id.to_string(), SUBSCHEMA_ID_BECH32);
+        assert_eq!(
+            id.to_string(),
+            "rgbsh1636y76cxrnsfqg7zjnl08f0kqt9j09tre2wfxzrrs86f76ssp7cqnn0yyf"
+        );
+    }
+
+    #[test]
+    fn schema_strict_encode() {
+        let data = schema()
+            .strict_serialize()
+            .expect("RGB-20 schema serialization failed");
+
+        let bech32data = data.bech32_zip_string();
+        println!("{}", bech32data);
+
+        let schema20 =
+            Schema::strict_deserialize(data).expect("RGB-20 schema deserialization failed");
+
+        assert_eq!(schema(), schema20);
+        assert_eq!(format!("{:#?}", schema()), format!("{:#?}", schema20));
+        assert_eq!(
+            bech32data,
+            "z1qxz4zwcwcgcqcl2d2tgnrzqtwq33swqzfvt43zkyepg49ky655klwg7cfefgg4pf38ewe78em8u6qwq5rgwx\
+            ah03mf0r4pg2q6nhk7exy2a32c8hk3hns7lm4yvrf7ux6m8pr6y3vy3vtt75f356s2dyr4q576cq8n9k42va5ut\
+            rfqnw7ysnkgyytecfqzy034s2cxqzt0nwnzzkyun24a2ljuwqt8xd0k3q6sd0wm4zmexvnjn3pge7w98kkvq2xd\
+            yc2kv5aa2d2tekv6lke8f6jc6z4hf290ccq08plf4h3u2t8nllq9cyvya79"
+        );
+    }
+
+    #[test]
+    fn subschema_verify() {
+        let status = subschema().schema_verify(&schema());
+        assert_eq!(status.validity(), Validity::Valid);
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,0 +1,14 @@
+// RGB20 Library: high-level API to RGB fungible assets.
+// Written in 2019-2022 by
+//     Dr. Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// To the extent possible under law, the author(s) have dedicated all copyright
+// and related and neighboring rights to this software to the public domain
+// worldwide. This software is distributed without any warranty.
+//
+// You should have received a copy of the MIT License along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+//! RGB20 schemata defining fungible asset smart contract prototypes.
+
+pub mod new;

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -11,4 +11,7 @@
 
 //! RGB20 schemata defining fungible asset smart contract prototypes.
 
-pub mod new;
+mod new;
+pub mod legacy;
+
+pub use new::{FieldType, OwnedRightType, Rgb20Schemata, TransitionType};

--- a/src/schema/new.rs
+++ b/src/schema/new.rs
@@ -9,8 +9,6 @@
 // You should have received a copy of the MIT License along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-//! RGB20 schemata defining fungible asset smart contract prototypes.
-
 use std::str::FromStr;
 
 use rgb::schema::{

--- a/src/transitions.rs
+++ b/src/transitions.rs
@@ -16,7 +16,8 @@ use rgb::fungible::allocation::{AllocationMap, AllocationValueMap, AllocationVal
 use rgb::prelude::*;
 use seals::txout::ExplicitSeal;
 
-use crate::{Asset, OwnedRightType, TransitionType};
+use crate::schema::{OwnedRightType, TransitionType};
+use crate::Asset;
 
 /// Errors happening during construction of RGB-20 asset state transitions
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, Error)]

--- a/src/transitions.rs
+++ b/src/transitions.rs
@@ -16,8 +16,7 @@ use rgb::fungible::allocation::{AllocationMap, AllocationValueMap, AllocationVal
 use rgb::prelude::*;
 use seals::txout::ExplicitSeal;
 
-use super::schema::{OwnedRightType, TransitionType};
-use super::Asset;
+use crate::{Asset, OwnedRightType, TransitionType};
 
 /// Errors happening during construction of RGB-20 asset state transitions
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, Error)]


### PR DESCRIPTION
This streamlines existing RGB20 subschemata into more reasonable sturcture.

The first subschema, called "inflationary" allows only secondary asset issuance - and not burn & replace or renomination operations.

The second subschema, called "simple", does not allow secondary issuance. It can be used only for asset transfers. The asset name or total supply can't be changed with this schema.